### PR TITLE
Fix enrollments

### DIFF
--- a/lib/Canvas.js
+++ b/lib/Canvas.js
@@ -9,7 +9,21 @@ const fs = require('fs')
 
 const canvasApi = CanvasApi(process.env.CANVAS_API_URL, process.env.CANVAS_API_TOKEN)
 
+/** Normalize the enrollments array to fit the schema */
+function normalizeEnrollments (enrollments) {
+  return enrollments
+    .filter(e => e.user_id && e.section_id && e.status && e.role_id)
+    .map(e => ({
+      user_id: e.user_id,
+      section_id: e.section_id,
+      status: e.status,
+      role_id: e.role_id
+    }))
+}
+
 module.exports = {
+  normalizeEnrollments,
+
   /** Return enrolled people as "Admitted not registered" in a given section SIS ID */
   async getAntagna (sectionSisId) {
     const enrollments = await canvasApi
@@ -32,17 +46,10 @@ module.exports = {
 
   /** Send enrollments to Canvas using a CSV file */
   async sendEnrollments (enrollments) {
-    const validEnrollments = enrollments
-      .filter(e => e.user_id && e.section_id && e.status && e.role_id)
-      .map(e => ({
-        user_id: e.user_id,
-        section_id: e.section_id,
-        status: e.status,
-        role_id: e.role_id
-      }))
+    const normalized = normalizeEnrollments(enrollments)
 
-    if (enrollments.length > validEnrollments.length) {
-      log.error(`SIS IMPORT: There are ${enrollments.length - validEnrollments.length} enrollments that are not going to be sent to Canvas due to incorrect formatting. Please check what you send to "Canvas.sendEnrollments"`)
+    if (enrollments.length > normalized.length) {
+      log.error(`SIS IMPORT: There are ${enrollments.length - normalized.length} enrollments that are not going to be sent to Canvas due to incorrect formatting. Please check what you send to "Canvas.sendEnrollments"`)
     }
 
     const file = tempy.file({ name: 'enrollments.csv' })
@@ -52,7 +59,7 @@ module.exports = {
     const stream = csv.format({ headers: true })
     stream.pipe(writer)
 
-    validEnrollments.forEach(e => stream.write(e))
+    normalized.forEach(e => stream.write(e))
     stream.end()
 
     await new Promise((resolve, reject) => {

--- a/lib/Canvas.js
+++ b/lib/Canvas.js
@@ -6,19 +6,22 @@ const CanvasApi = require('@kth/canvas-api')
 const csv = require('fast-csv')
 const tempy = require('tempy')
 const fs = require('fs')
+const Joi = require('@hapi/joi')
 
 const canvasApi = CanvasApi(process.env.CANVAS_API_URL, process.env.CANVAS_API_TOKEN)
+
+const enrollmentSchema = Joi.object().keys({
+  user_id: Joi.required(),
+  section_id: Joi.required(),
+  status: Joi.required(),
+  role_id: Joi.required()
+})
 
 /** Normalize the enrollments array to fit the schema */
 function normalizeEnrollments (enrollments) {
   return enrollments
-    .filter(e => e.user_id && e.section_id && e.status && e.role_id)
-    .map(e => ({
-      user_id: e.user_id,
-      section_id: e.section_id,
-      status: e.status,
-      role_id: e.role_id
-    }))
+    .filter(e => enrollmentSchema.validate(e, { stripUnknown: true }).error === null)
+    .map(e => enrollmentSchema.validate(e, { stripUnknown: true }).value)
 }
 
 module.exports = {

--- a/lib/Canvas.js
+++ b/lib/Canvas.js
@@ -33,10 +33,16 @@ module.exports = {
   /** Send enrollments to Canvas using a CSV file */
   async sendEnrollments (enrollments) {
     const validEnrollments = enrollments
-      .filter(e => e.user_id && e.section_id && e.status && e.role)
+      .filter(e => e.user_id && e.section_id && e.status && e.role_id)
+      .map(e => ({
+        user_id: e.user_id,
+        section_id: e.section_id,
+        status: e.status,
+        role_id: e.role_id
+      }))
 
     if (enrollments.length > validEnrollments.length) {
-      log.warn(`SIS IMPORT: There are ${enrollments.length - validEnrollments.length} enrollments that are not going to be sent to Canvas due to incorrect formatting. Please check what you send to "Canvas.sendEnrollments"`)
+      log.error(`SIS IMPORT: There are ${enrollments.length - validEnrollments.length} enrollments that are not going to be sent to Canvas due to incorrect formatting. Please check what you send to "Canvas.sendEnrollments"`)
     }
 
     const file = tempy.file({ name: 'enrollments.csv' })
@@ -46,7 +52,7 @@ module.exports = {
     const stream = csv.format({ headers: true })
     stream.pipe(writer)
 
-    enrollments.forEach(e => stream.write(e))
+    validEnrollments.forEach(e => stream.write(e))
     stream.end()
 
     await new Promise((resolve, reject) => {

--- a/lib/Canvas.test.js
+++ b/lib/Canvas.test.js
@@ -1,6 +1,7 @@
 const test = require('ava')
 const createTestServer = require('create-test-server')
 const proxyquire = require('proxyquire').noPreserveCache()
+const Canvas = require('./Canvas')
 
 test.serial('Canvas.getAntagna() returns only users with SIS ID', async t => {
   const server = await createTestServer()
@@ -38,4 +39,33 @@ test.serial('Canvas.getAntagna() returns only the SIS ID', async t => {
   t.deepEqual(enrollments, [
     { sis_user_id: 'aaa' }
   ])
+})
+
+test.serial('Canvas.normalizeEnrollments() return objects with all the valid keys', t => {
+  const input = [
+    { user_id: 'user', section_id: 'section', status: 'active', role_id: 12 },
+    { user_id: 'user', xxxx_section_id: 'section', status: 'active', role_id: 12 }
+  ]
+
+  const expected = [
+    { user_id: 'user', section_id: 'section', status: 'active', role_id: 12 }
+  ]
+  const result = Canvas.normalizeEnrollments(input)
+
+  t.deepEqual(result, expected)
+})
+
+test.serial('Canvas.normalizeEnrollments() return objects without the non-valid keys', t => {
+  const input = [
+    { user_id: 'user', section_id: 'section', status: 'active', role_id: 12 },
+    { user_id: 'user', section_id: 'section2', status: 'active', role_id: 12, role: 'nothing' }
+  ]
+
+  const expected = [
+    { user_id: 'user', section_id: 'section', status: 'active', role_id: 12 },
+    { user_id: 'user', section_id: 'section2', status: 'active', role_id: 12 }
+  ]
+  const result = Canvas.normalizeEnrollments(input)
+
+  t.deepEqual(result, expected)
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -372,6 +372,40 @@
         }
       }
     },
+    "@hapi/address": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.0.0.tgz",
+      "integrity": "sha512-mV6T0IYqb0xL1UALPFplXYQmR0twnXG0M6jUswpquqT2sD12BOiCiLy3EvMp/Fy7s3DZElC4/aPjEjo2jeZpvw=="
+    },
+    "@hapi/bourne": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
+      "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA=="
+    },
+    "@hapi/hoek": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.2.1.tgz",
+      "integrity": "sha512-JPiBy+oSmsq3St7XlipfN5pNA6bDJ1kpa73PrK/zR29CVClDVqy04AanM/M/qx5bSF+I61DdCfAvRrujau+zRg=="
+    },
+    "@hapi/joi": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
+      "integrity": "sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==",
+      "requires": {
+        "@hapi/address": "2.x.x",
+        "@hapi/bourne": "1.x.x",
+        "@hapi/hoek": "8.x.x",
+        "@hapi/topo": "3.x.x"
+      }
+    },
+    "@hapi/topo": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.3.tgz",
+      "integrity": "sha512-JmS9/vQK6dcUYn7wc2YZTqzIKubAQcJKu2KCKAru6es482U5RT5fP1EXCPtlXpiK7PR0On/kpQKI4fRKkzpZBQ==",
+      "requires": {
+        "@hapi/hoek": "8.x.x"
+      }
+    },
     "@kth/canvas-api": {
       "version": "2.1.0-beta.2",
       "resolved": "https://registry.npmjs.org/@kth/canvas-api/-/canvas-api-2.1.0-beta.2.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "standard": "^12.0.1"
   },
   "dependencies": {
+    "@hapi/joi": "^15.1.1",
     "@kth/canvas-api": "^2.1.0-beta.2",
     "bunyan": "^1.8.12",
     "cls-hooked": "^4.2.2",


### PR DESCRIPTION
Before this PR, a log was sent when the enrollments had wrong format (when some of the fields like `user_id`, `section_id` were missing). The log was sent but the program used the "wrong" array instead of the cleaned one.

When we changed the format to use `role_id` instead of `role`, the log was sending warnings but the array with a "wrong" `role_id` field was still used normally.

This fix sends higher severity error messages to the log and adds tests to check better the format of the `enrollments` array.