### PR TITLE
Sync +/- 5 periods

### DIFF
--- a/.env.in
+++ b/.env.in
@@ -6,11 +6,17 @@ UG_USERNAME=system-lms-integration@ug.kth.se
 UG_PASSWORD=
 KOPPS_API_URL=https://www.kth.se/api/kopps/v2/
 
-# PERIOD specifies the Period for which students will be enrolled.
-# Additionally, students from previous period will be UN-enrolled.
+# PERIOD specifies the first Period for which students will be enrolled.
+# Students from the specified period and the following four will be enrolled
+# Additionally, students from five previous periods will be un-enrolled.
+#
 #   For example, if PERIOD is set to "2019-HT-P1" (meaning Year 2019, Autumn
-#   Term, Period 1), antagna students from previous period (in this case P0)
-#   will be unenrolled, and antagna students from period P1, will be enrolled.
+#   Term, Period 1) students from the following five periods will be enrolled:
+#   2019-HT-P1, 2019-HT-P2, 2020-VT-P3, 2020-VT-P4, 2020-VT-P5
+#
+#   And students from the following five periods will be un-enrolled:
+#   2019-HT-P0, 2019-VT-P5, 2019-VT-P4, 2019-VT-P3, 2018-HT-P2
+#
 PERIOD=2019-HT-P1
 
 # From this point, all the environmental variables are optional

--- a/cron/index.js
+++ b/cron/index.js
@@ -17,6 +17,7 @@ const INTERVAL = process.env.INTERVAL || '0 5 * * *'
 // "0,30 * * * *" = "Every 30 minutes (at X:00 and X:30)"
 const FAILURE_INTERVAL = '0,30 * * * *'
 
+// Read `.env.in` for more information about the "PERIOD" env var
 const currentPeriod = Period.fromString(process.env.PERIOD)
 
 let job

--- a/cron/index.js
+++ b/cron/index.js
@@ -17,7 +17,7 @@ const INTERVAL = process.env.INTERVAL || '0 5 * * *'
 // "0,30 * * * *" = "Every 30 minutes (at X:00 and X:30)"
 const FAILURE_INTERVAL = '0,30 * * * *'
 
-const PERIOD = Period(process.env.PERIOD)
+const currentPeriod = Period.fromString(process.env.PERIOD)
 const START_OFFSET = -5
 const END_OFFSET = 5
 
@@ -35,18 +35,18 @@ async function sync () {
   running = true
 
   await log.child({ req_id: cuid() }, async () => {
-    const remove0 = PERIOD.offset(START_OFFSET)
-    const remove1 = PERIOD.offset(-1)
+    const remove0 = currentPeriod.offset(START_OFFSET)
+    const remove1 = currentPeriod.offset(-1)
 
-    const add0 = PERIOD
-    const add1 = PERIOD.offset(END_OFFSET)
+    const add0 = currentPeriod
+    const add1 = currentPeriod.offset(END_OFFSET)
     log.info(
-      `Starting sync. Current: ${PERIOD}\n- Remove ${remove0} to ${remove1}\n- Add    ${add0} to ${add1}`
+      `Starting sync. Current: ${currentPeriod}\n- Remove ${remove0} to ${remove1}\n- Add    ${add0} to ${add1}`
     )
 
     try {
-      const removeRange = PERIOD.range(START_OFFSET, -1)
-      const addRange = PERIOD.range(0, END_OFFSET)
+      const removeRange = Period.range(currentPeriod, START_OFFSET, -1)
+      const addRange = Period.range(currentPeriod, 0, END_OFFSET)
       const enrollments = []
 
       for (const period of removeRange) {

--- a/lib/get-enrollments.js
+++ b/lib/get-enrollments.js
@@ -75,7 +75,7 @@ module.exports = {
       try {
         const kthIds = await ug.getAntagna(
           round.course_code,
-          period.koppsTerm(),
+          period.toKoppsString(),
           round.round_id
         )
         log.debug(

--- a/lib/get-enrollments.js
+++ b/lib/get-enrollments.js
@@ -75,7 +75,7 @@ module.exports = {
       try {
         const kthIds = await ug.getAntagna(
           round.course_code,
-          period.toKoppsString(),
+          period.toKoppsTermString(),
           round.round_id
         )
         log.debug(

--- a/lib/kopps.js
+++ b/lib/kopps.js
@@ -12,7 +12,7 @@ module.exports = {
         url: '/courses/offerings',
         json: true,
         query: {
-          from: period.koppsTerm(),
+          from: period.toKoppsString(),
           skip_coordinator_info: true
         }
       })
@@ -40,7 +40,7 @@ module.exports = {
 
     return cleanCourseRounds
       .filter(c => c.state === 'Godkänt' || c.state === 'Fullsatt')
-      .filter(c => c.first_period === period.koppsPeriod())
+      .filter(c => c.first_period === period.toKoppsString(true))
       .map(c => ({
         course_code: c.course_code,
         round_id: c.offering_id,

--- a/lib/kopps.js
+++ b/lib/kopps.js
@@ -12,7 +12,7 @@ module.exports = {
         url: '/courses/offerings',
         json: true,
         query: {
-          from: period.toKoppsString(),
+          from: period.toKoppsTermString(),
           skip_coordinator_info: true
         }
       })
@@ -40,9 +40,7 @@ module.exports = {
 
     return cleanCourseRounds
       .filter(c => c.state === 'Godkänt' || c.state === 'Fullsatt')
-      .filter(
-        c => c.first_period === period.toKoppsString({ includePeriod: true })
-      )
+      .filter(c => c.first_period === period.toKoppsPeriodString())
       .map(c => ({
         course_code: c.course_code,
         round_id: c.offering_id,

--- a/lib/kopps.js
+++ b/lib/kopps.js
@@ -40,7 +40,9 @@ module.exports = {
 
     return cleanCourseRounds
       .filter(c => c.state === 'Godkänt' || c.state === 'Fullsatt')
-      .filter(c => c.first_period === period.toKoppsString(true))
+      .filter(
+        c => c.first_period === period.toKoppsString({ includePeriod: true })
+      )
       .map(c => ({
         course_code: c.course_code,
         round_id: c.offering_id,

--- a/lib/period.js
+++ b/lib/period.js
@@ -43,8 +43,8 @@ module.exports = class Period {
   }
 
   /** Get the term associated with a period number */
-  static getTerm (period) {
-    if (period <= 2) {
+  static getTerm (periodNumber) {
+    if (periodNumber <= 2) {
       return 'HT'
     } else {
       return 'VT'
@@ -80,41 +80,41 @@ module.exports = class Period {
 
   /** Return the next period */
   next () {
-    let year = this.year
-    let period = this.period + 1
+    let newYear = this.year
+    let newPeriod = this.period + 1
 
-    if (period === 3) {
-      year = year + 1
+    if (newPeriod === 3) {
+      newYear = newYear + 1
     }
 
-    if (period === 6) {
-      period = 0
+    if (newPeriod === 6) {
+      newPeriod = 0
     }
 
     return new Period({
-      year,
-      term: Period.getTerm(period),
-      period
+      year: newYear,
+      term: Period.getTerm(newPeriod),
+      period: newPeriod
     })
   }
 
   /** Return the previous period */
   prev () {
-    let year = this.year
-    let period = this.period - 1
+    let newYear = this.year
+    let newPeriod = this.period - 1
 
-    if (period === 2) {
-      year = year - 1
+    if (newPeriod === 2) {
+      newYear = newYear - 1
     }
 
-    if (period === -1) {
-      period = 5
+    if (newPeriod === -1) {
+      newPeriod = 5
     }
 
     return new Period({
-      year,
-      term: Period.getTerm(period),
-      period
+      year: newYear,
+      term: Period.getTerm(newPeriod),
+      period: newPeriod
     })
   }
 

--- a/lib/period.js
+++ b/lib/period.js
@@ -18,6 +18,17 @@ function prevPeriod ({ year, period }) {
   }
 }
 
+function nextPeriod ({ year, period }) {
+  const y2 = period + 1 === 3 ? year + 1 : year
+  const p2 = period + 1 > 5 ? 0 : period + 1
+
+  return {
+    year: y2,
+    term: getTerm(p2),
+    period: p2
+  }
+}
+
 /** Constructor from String */
 function Period (str) {
   const matching = str.match(/^(\d+)-(VT|HT)-P(\d)$/)
@@ -30,7 +41,11 @@ function Period (str) {
 
   const [, year, term, period] = matching
 
-  return Period.fromObject({ year, term, period })
+  return Period.fromObject({
+    year: parseInt(year, 10),
+    term,
+    period: parseInt(period, 10)
+  })
 }
 
 /** Constructor from {year, term, period} object */
@@ -50,6 +65,9 @@ Period.fromObject = function ({ year, term, period }) {
   return {
     prevPeriod () {
       return Period.fromObject(prevPeriod({ year, period }))
+    },
+    nextPeriod () {
+      return Period.fromObject(nextPeriod({ year, period }))
     },
     toString () {
       return `${year}-${term}-P${period}`

--- a/lib/period.js
+++ b/lib/period.js
@@ -1,105 +1,133 @@
-/** "Period" object to transform between diverse Period formats */
-function getTerm (period) {
-  if (period <= 2) {
-    return 'HT'
-  } else {
-    return 'VT'
-  }
-}
+module.exports = class Period {
+  /**
+   * @param {object} obj
+   * @param {number} obj.year Year
+   * @param {string} obj.term "HT" or "VT"
+   * @param {number} obj.period
+   */
+  constructor ({ year, term, period }) {
+    if (period > 5) {
+      throw new Error(
+        `Wrong format. Period [P${period}] does not exist. Should be from 0 to 5`
+      )
+    }
 
-function prevPeriod ({ year, period }) {
-  const y2 = period - 1 === 2 ? year - 1 : year
-  const p2 = period - 1 < 0 ? 5 : period - 1
+    if (Period.getTerm(period) !== term) {
+      throw new Error(
+        `Wrong format. [${term}-P${period}] does not exist. Valids are HT-P0, HT-P1, HT-P2, VT-P3, VT-P4, VT-P5`
+      )
+    }
 
-  return {
-    year: y2,
-    term: getTerm(p2),
-    period: p2
-  }
-}
-
-function nextPeriod ({ year, period }) {
-  const y2 = period + 1 === 3 ? year + 1 : year
-  const p2 = period + 1 > 5 ? 0 : period + 1
-
-  return {
-    year: y2,
-    term: getTerm(p2),
-    period: p2
-  }
-}
-
-/** Constructor from String */
-function Period (str) {
-  const matching = str.match(/^(\d+)-(VT|HT)-P(\d)$/)
-
-  if (!matching) {
-    throw new Error(
-      'Wrong format. String must be formatted as "YYYY-TT-PP" (example: "2019-VT-P3")'
-    )
+    this.year = year
+    this.term = term
+    this.period = period
   }
 
-  const [, year, term, period] = matching
+  /** Alternative constructor from a String instead of passing "year", "term", "period" */
+  static fromString (str) {
+    const matching = str.match(/^(\d+)-(VT|HT)-P(\d)$/)
 
-  return Period.fromObject({
-    year: parseInt(year, 10),
-    term,
-    period: parseInt(period, 10)
-  })
-}
+    if (!matching) {
+      throw new Error(
+        'Wrong format. String must be formatted as "YYYY-TT-PP" (example: "2019-VT-P3")'
+      )
+    }
 
-/** Constructor from {year, term, period} object */
-Period.fromObject = function ({ year, term, period }) {
-  if (period > 5) {
-    throw new Error(
-      `Wrong format. Period [P${period}] does not exist. Should be from 0 to 5`
-    )
+    const [, year, term, period] = matching
+
+    return new Period({
+      year: parseInt(year, 10),
+      term,
+      period: parseInt(period, 10)
+    })
   }
 
-  if (getTerm(period) !== term) {
-    throw new Error(
-      `Wrong format. [${term}-P${period}] does not exist. Valids are HT-P0, HT-P1, HT-P2, VT-P3, VT-P4, VT-P5`
-    )
-  }
-
-  return {
-    prevPeriod () {
-      return Period.fromObject(prevPeriod({ year, period }))
-    },
-    nextPeriod () {
-      return Period.fromObject(nextPeriod({ year, period }))
-    },
-    offset (n) {
-      if (n > 0) {
-        return this.nextPeriod().offset(n - 1)
-      } else if (n < 0) {
-        return this.prevPeriod().offset(n + 1)
-      }
-
-      return this
-    },
-    toString () {
-      return `${year}-${term}-P${period}`
-    },
-    koppsTerm () {
-      return `${year}${term === 'VT' ? 1 : 2}`
-    },
-    koppsPeriod () {
-      return `${year}${term === 'VT' ? 1 : 2}P${period}`
-    },
-    range (startOffset, endOffset) {
-      if (startOffset > endOffset) {
-        throw new Error(
-          `Wrong parameters. "startOffset" should be smaller than "endOffset"`
-        )
-      }
-
-      return Array.from(
-        { length: endOffset - startOffset + 1 },
-        (x, i) => i + startOffset
-      ).map(v => this.offset(v))
+  /** Get the term associated with a period number */
+  static getTerm (period) {
+    if (period <= 2) {
+      return 'HT'
+    } else {
+      return 'VT'
     }
   }
-}
 
-module.exports = Period
+  /**
+   * Get a range of periods between (period - startOffset) and (period + endOffset)
+   * @param {Period} period
+   */
+  static range (period, startOffset, endOffset) {
+    const length = endOffset - startOffset + 1
+    const offsets = Array.from({ length }, (x, i) => i + startOffset)
+
+    return offsets.map(v => period.add(v))
+  }
+
+  /** Return a string representation of the Period */
+  toString () {
+    return `${this.year}-${this.term}-P${this.period}`
+  }
+
+  /** Return the Period in "<year><term>" format (where term is 1 or 2) */
+  toKoppsString (includePeriod = false) {
+    const koppsTerm = this.term === 'VT' ? 1 : 2
+
+    if (includePeriod) {
+      return `${this.year}${koppsTerm}P${this.period}`
+    } else {
+      return `${this.year}${koppsTerm}`
+    }
+  }
+
+  /** Return the next period */
+  next () {
+    let year = this.year
+    let period = this.period + 1
+
+    if (period === 3) {
+      year = year + 1
+    }
+
+    if (period === 6) {
+      period = 0
+    }
+
+    return new Period({
+      year,
+      term: Period.getTerm(period),
+      period
+    })
+  }
+
+  /** Return the previous period */
+  prev () {
+    let year = this.year
+    let period = this.period - 1
+
+    if (period === 2) {
+      year = year - 1
+    }
+
+    if (period === -1) {
+      period = 5
+    }
+
+    return new Period({
+      year,
+      term: Period.getTerm(period),
+      period
+    })
+  }
+
+  /** Add "n" periods to the Period
+   * @returns {Period}
+   */
+  add (n) {
+    if (n > 0) {
+      return this.next().add(n - 1)
+    } else if (n < 0) {
+      return this.prev().add(n + 1)
+    }
+
+    return this
+  }
+}

--- a/lib/period.js
+++ b/lib/period.js
@@ -25,7 +25,7 @@ module.exports = class Period {
 
   /** Alternative constructor from a String instead of passing "year", "term", "period" */
   static fromString (str) {
-    const matching = str.match(/^(\d+)-(VT|HT)-P(\d)$/)
+    const matching = str.match(/^(\d{4})-(VT|HT)-P(\d)$/)
 
     if (!matching) {
       throw new Error(

--- a/lib/period.js
+++ b/lib/period.js
@@ -68,7 +68,7 @@ module.exports = class Period {
   }
 
   /** Return the Period in "<year><term>" format (where term is 1 or 2) */
-  toKoppsString (includePeriod = false) {
+  toKoppsString ({ includePeriod = false } = {}) {
     const koppsTerm = this.term === 'VT' ? 1 : 2
 
     if (includePeriod) {

--- a/lib/period.js
+++ b/lib/period.js
@@ -68,14 +68,17 @@ module.exports = class Period {
   }
 
   /** Return the Period in "<year><term>" format (where term is 1 or 2) */
-  toKoppsString ({ includePeriod = false } = {}) {
+  toKoppsTermString () {
     const koppsTerm = this.term === 'VT' ? 1 : 2
 
-    if (includePeriod) {
-      return `${this.year}${koppsTerm}P${this.period}`
-    } else {
-      return `${this.year}${koppsTerm}`
-    }
+    return `${this.year}${koppsTerm}`
+  }
+
+  /** Return the Period in "<year><term><period>" format (where term is 1 or 2) */
+  toKoppsPeriodString () {
+    const koppsTerm = this.term === 'VT' ? 1 : 2
+
+    return `${this.year}${koppsTerm}P${this.period}`
   }
 
   /** Return the next period */

--- a/lib/period.js
+++ b/lib/period.js
@@ -69,6 +69,15 @@ Period.fromObject = function ({ year, term, period }) {
     nextPeriod () {
       return Period.fromObject(nextPeriod({ year, period }))
     },
+    offset (n) {
+      if (n > 0) {
+        return this.nextPeriod().offset(n - 1)
+      } else if (n < 0) {
+        return this.prevPeriod().offset(n + 1)
+      }
+
+      return this
+    },
     toString () {
       return `${year}-${term}-P${period}`
     },
@@ -77,6 +86,18 @@ Period.fromObject = function ({ year, term, period }) {
     },
     koppsPeriod () {
       return `${year}${term === 'VT' ? 1 : 2}P${period}`
+    },
+    range (startOffset, endOffset) {
+      if (startOffset > endOffset) {
+        throw new Error(
+          `Wrong parameters. "startOffset" should be smaller than "endOffset"`
+        )
+      }
+
+      return Array.from(
+        { length: endOffset - startOffset + 1 },
+        (x, i) => i + startOffset
+      ).map(v => this.offset(v))
     }
   }
 }

--- a/lib/period.test.js
+++ b/lib/period.test.js
@@ -2,25 +2,25 @@ const Period = require('./period')
 const test = require('ava')
 
 test('Period throws if given format is wrong', t => {
-  t.throws(() => Period('2019VT-P1'))
+  t.throws(() => Period.fromString('2019VT-P1'))
 })
 
 test('Period throws if the term is not valid', t => {
   // Period from 6 to 9 do not exist
-  t.throws(() => Period('2019-VT-P6'))
-  t.throws(() => Period('2019-VT-P7'))
-  t.throws(() => Period('2019-VT-P8'))
-  t.throws(() => Period('2019-VT-P9'))
+  t.throws(() => Period.fromString('2019-VT-P6'))
+  t.throws(() => Period.fromString('2019-VT-P7'))
+  t.throws(() => Period.fromString('2019-VT-P8'))
+  t.throws(() => Period.fromString('2019-VT-P9'))
 
   // HT only matches with Periods 0, 1, 2
-  t.throws(() => Period('2019-VT-P0'))
-  t.throws(() => Period('2019-VT-P1'))
-  t.throws(() => Period('2019-VT-P2'))
+  t.throws(() => Period.fromString('2019-VT-P0'))
+  t.throws(() => Period.fromString('2019-VT-P1'))
+  t.throws(() => Period.fromString('2019-VT-P2'))
 
   // VT only matches with Periods 3, 4, 5
-  t.throws(() => Period('2019-HT-P3'))
-  t.throws(() => Period('2019-HT-P4'))
-  t.throws(() => Period('2019-HT-P5'))
+  t.throws(() => Period.fromString('2019-HT-P3'))
+  t.throws(() => Period.fromString('2019-HT-P4'))
+  t.throws(() => Period.fromString('2019-HT-P5'))
 })
 
 test('Period.previous() returns the previous period', t => {
@@ -33,10 +33,10 @@ test('Period.previous() returns the previous period', t => {
 
   for (const [previous, current] of periods) {
     t.is(
-      Period(current)
-        .prevPeriod()
+      Period.fromString(current)
+        .prev()
         .toString(),
-      Period(previous).toString()
+      previous
     )
   }
 })
@@ -51,22 +51,22 @@ test('Period.nextPeriod() returns the previous period', t => {
 
   for (const [current, next] of periods) {
     t.is(
-      Period(current)
-        .nextPeriod()
+      Period.fromString(current)
+        .next()
         .toString(),
-      Period(next).toString(),
+      next,
       `Next from ${current} should be ${next}`
     )
   }
 })
 
-test('Period.koppsTerm() returns the correct term', t => {
-  t.is(Period('2019-VT-P3').koppsTerm(), '20191')
-  t.is(Period('2019-HT-P0').koppsTerm(), '20192')
+test('Period.toKoppsString() returns the correct term', t => {
+  t.is(Period.fromString('2019-VT-P3').toKoppsString(), '20191')
+  t.is(Period.fromString('2019-HT-P0').toKoppsString(), '20192')
 })
 
-test('Period.offset() returns the correct term', t => {
-  const current = Period('2020-HT-P2')
+test('Period.add() returns the correct term', t => {
+  const current = Period.fromString('2020-HT-P2')
   const expected = [
     '2020-VT-P3',
     '2020-VT-P4',
@@ -82,12 +82,12 @@ test('Period.offset() returns the correct term', t => {
   ]
 
   for (let i = 0; i < expected.length; i++) {
-    t.is(current.offset(i - 5).toString(), expected[i])
+    t.is(current.add(i - 5).toString(), expected[i])
   }
 })
 
 test('Period.range() returns a range of periods', t => {
-  const current = Period('2020-HT-P2')
+  const current = Period.fromString('2020-HT-P2')
   const expected = [
     '2020-VT-P3',
     '2020-VT-P4',
@@ -104,5 +104,5 @@ test('Period.range() returns a range of periods', t => {
     '2021-HT-P1'
   ]
 
-  t.deepEqual(current.range(-5, 5).map(c => c.toString()), expected)
+  t.deepEqual(Period.range(current, -5, 5).map(c => c.toString()), expected)
 })

--- a/lib/period.test.js
+++ b/lib/period.test.js
@@ -6,6 +6,9 @@ test('Period throws if given format is wrong', t => {
 })
 
 test('Period throws if the term is not valid', t => {
+  // year should be 4 digits
+  t.throws(() => Period.fromString('20-VT-P3'))
+
   // Period from 6 to 9 do not exist
   t.throws(() => Period.fromString('2019-VT-P6'))
   t.throws(() => Period.fromString('2019-VT-P7'))

--- a/lib/period.test.js
+++ b/lib/period.test.js
@@ -42,6 +42,15 @@ test('Period.nextPeriod() returns the previous period', t => {
 test('Period.toKoppsString() returns the correct term', t => {
   t.is(Period.fromString('2019-VT-P3').toKoppsString(), '20191')
   t.is(Period.fromString('2019-HT-P0').toKoppsString(), '20192')
+
+  t.is(
+    Period.fromString('2019-VT-P3').toKoppsString({ includePeriod: true }),
+    '20191P3'
+  )
+  t.is(
+    Period.fromString('2019-HT-P0').toKoppsString({ includePeriod: true }),
+    '20192P0'
+  )
 })
 
 test('Period.add() returns the correct term', t => {

--- a/lib/period.test.js
+++ b/lib/period.test.js
@@ -23,41 +23,20 @@ test('Period throws if the term is not valid', t => {
   t.throws(() => Period.fromString('2019-HT-P5'))
 })
 
+// prettier-ignore
 test('Period.previous() returns the previous period', t => {
-  const periods = [
-    ['2018-VT-P3', '2018-VT-P4'],
-    ['2018-VT-P5', '2018-HT-P0'],
-    ['2018-HT-P1', '2018-HT-P2'],
-    ['2018-HT-P2', '2019-VT-P3']
-  ]
-
-  for (const [previous, current] of periods) {
-    t.is(
-      Period.fromString(current)
-        .prev()
-        .toString(),
-      previous
-    )
-  }
+  t.is(Period.fromString('2018-VT-P4').prev().toString(), '2018-VT-P3')
+  t.is(Period.fromString('2018-HT-P0').prev().toString(), '2018-VT-P5')
+  t.is(Period.fromString('2018-HT-P2').prev().toString(), '2018-HT-P1')
+  t.is(Period.fromString('2018-VT-P3').prev().toString(), '2017-HT-P2')
 })
 
+// prettier-ignore
 test('Period.nextPeriod() returns the previous period', t => {
-  const periods = [
-    ['2018-VT-P3', '2018-VT-P4'],
-    ['2018-VT-P5', '2018-HT-P0'],
-    ['2018-HT-P1', '2018-HT-P2'],
-    ['2018-HT-P2', '2019-VT-P3']
-  ]
-
-  for (const [current, next] of periods) {
-    t.is(
-      Period.fromString(current)
-        .next()
-        .toString(),
-      next,
-      `Next from ${current} should be ${next}`
-    )
-  }
+  t.is(Period.fromString('2018-VT-P3').next().toString(), '2018-VT-P4')
+  t.is(Period.fromString('2018-VT-P5').next().toString(), '2018-HT-P0')
+  t.is(Period.fromString('2018-HT-P1').next().toString(), '2018-HT-P2')
+  t.is(Period.fromString('2018-HT-P2').next().toString(), '2019-VT-P3')
 })
 
 test('Period.toKoppsString() returns the correct term', t => {
@@ -67,23 +46,17 @@ test('Period.toKoppsString() returns the correct term', t => {
 
 test('Period.add() returns the correct term', t => {
   const current = Period.fromString('2020-HT-P2')
-  const expected = [
-    '2020-VT-P3',
-    '2020-VT-P4',
-    '2020-VT-P5',
-    '2020-HT-P0',
-    '2020-HT-P1',
-    '2020-HT-P2',
-    '2021-VT-P3',
-    '2021-VT-P4',
-    '2021-VT-P5',
-    '2021-HT-P0',
-    '2021-HT-P1'
-  ]
-
-  for (let i = 0; i < expected.length; i++) {
-    t.is(current.add(i - 5).toString(), expected[i])
-  }
+  t.is(current.add(-5).toString(), '2020-VT-P3')
+  t.is(current.add(-4).toString(), '2020-VT-P4')
+  t.is(current.add(-3).toString(), '2020-VT-P5')
+  t.is(current.add(-2).toString(), '2020-HT-P0')
+  t.is(current.add(-1).toString(), '2020-HT-P1')
+  t.is(current.add(0).toString(), '2020-HT-P2')
+  t.is(current.add(1).toString(), '2021-VT-P3')
+  t.is(current.add(2).toString(), '2021-VT-P4')
+  t.is(current.add(3).toString(), '2021-VT-P5')
+  t.is(current.add(4).toString(), '2021-HT-P0')
+  t.is(current.add(5).toString(), '2021-HT-P1')
 })
 
 test('Period.range() returns a range of periods', t => {

--- a/lib/period.test.js
+++ b/lib/period.test.js
@@ -39,18 +39,14 @@ test('Period.nextPeriod() returns the previous period', t => {
   t.is(Period.fromString('2018-HT-P2').next().toString(), '2019-VT-P3')
 })
 
-test('Period.toKoppsString() returns the correct term', t => {
-  t.is(Period.fromString('2019-VT-P3').toKoppsString(), '20191')
-  t.is(Period.fromString('2019-HT-P0').toKoppsString(), '20192')
+test('Period.toKoppsTermString() formats correctly', t => {
+  t.is(Period.fromString('2019-VT-P3').toKoppsTermString(), '20191')
+  t.is(Period.fromString('2019-HT-P0').toKoppsTermString(), '20192')
+})
 
-  t.is(
-    Period.fromString('2019-VT-P3').toKoppsString({ includePeriod: true }),
-    '20191P3'
-  )
-  t.is(
-    Period.fromString('2019-HT-P0').toKoppsString({ includePeriod: true }),
-    '20192P0'
-  )
+test('Period.toKoppsPeriodString() formats correctly', t => {
+  t.is(Period.fromString('2019-VT-P3').toKoppsPeriodString(), '20191P3')
+  t.is(Period.fromString('2019-HT-P0').toKoppsPeriodString(), '20192P0')
 })
 
 test('Period.add() returns the correct term', t => {

--- a/lib/period.test.js
+++ b/lib/period.test.js
@@ -64,3 +64,45 @@ test('Period.koppsTerm() returns the correct term', t => {
   t.is(Period('2019-VT-P3').koppsTerm(), '20191')
   t.is(Period('2019-HT-P0').koppsTerm(), '20192')
 })
+
+test('Period.offset() returns the correct term', t => {
+  const current = Period('2020-HT-P2')
+  const expected = [
+    '2020-VT-P3',
+    '2020-VT-P4',
+    '2020-VT-P5',
+    '2020-HT-P0',
+    '2020-HT-P1',
+    '2020-HT-P2',
+    '2021-VT-P3',
+    '2021-VT-P4',
+    '2021-VT-P5',
+    '2021-HT-P0',
+    '2021-HT-P1'
+  ]
+
+  for (let i = 0; i < expected.length; i++) {
+    t.is(current.offset(i - 5).toString(), expected[i])
+  }
+})
+
+test('Period.range() returns a range of periods', t => {
+  const current = Period('2020-HT-P2')
+  const expected = [
+    '2020-VT-P3',
+    '2020-VT-P4',
+    '2020-VT-P5',
+    '2020-HT-P0',
+    '2020-HT-P1',
+
+    '2020-HT-P2',
+
+    '2021-VT-P3',
+    '2021-VT-P4',
+    '2021-VT-P5',
+    '2021-HT-P0',
+    '2021-HT-P1'
+  ]
+
+  t.deepEqual(current.range(-5, 5).map(c => c.toString()), expected)
+})

--- a/lib/period.test.js
+++ b/lib/period.test.js
@@ -41,6 +41,25 @@ test('Period.previous() returns the previous period', t => {
   }
 })
 
+test('Period.nextPeriod() returns the previous period', t => {
+  const periods = [
+    ['2018-VT-P3', '2018-VT-P4'],
+    ['2018-VT-P5', '2018-HT-P0'],
+    ['2018-HT-P1', '2018-HT-P2'],
+    ['2018-HT-P2', '2019-VT-P3']
+  ]
+
+  for (const [current, next] of periods) {
+    t.is(
+      Period(current)
+        .nextPeriod()
+        .toString(),
+      Period(next).toString(),
+      `Next from ${current} should be ${next}`
+    )
+  }
+})
+
 test('Period.koppsTerm() returns the correct term', t => {
   t.is(Period('2019-VT-P3').koppsTerm(), '20191')
   t.is(Period('2019-HT-P0').koppsTerm(), '20192')


### PR DESCRIPTION
This PR implements logic for synchronizing antagna students for +/- 5 periods:
- Removes antagna students for -5 ~ -1 periods.
- Adds antagna students for 0 ~ +5 periods.

For example:

+/- | Period | Action
:--:|:--:|:--:
-5 | 2020-VT-P3 | remove
-4 | 2020-VT-P4 | remove
-3 | 2020-VT-P5 | remove
-2 | 2020-HT-P0 | remove
-1 | 2020-HT-P1 | remove
**current** | **2020-HT-P2** | **add**
+1 | 2021-VT-P3 | add
+2 | 2021-VT-P4 | add
+3 | 2021-VT-P5 | add
+4 | 2021-HT-P0 | add
+5 | 2021-HT-P1 | add